### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+v0.1.0
+
+* `maxDistance` changed to `maxReRouteDistance`
+* Added option `maxSnapToLocation`
+* `findNextStep` returns snapped location to route now on key `snapToLocation`
+
+v0.0.1
+
+* Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-v0.1.0
+# v0.1.0
 
 * `maxDistance` changed to `maxReRouteDistance`
 * Added option `maxSnapToLocation`
 * `findNextStep` returns snapped location to route now on key `snapToLocation`
 
-v0.0.1
+# v0.0.1
 
 * Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigation.js",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# v0.1.0
- `maxDistance` changed to `maxReRouteDistance`
- Added option `maxSnapToLocation`
- `findNextStep` returns snapped location to route now on key `snapToLocation`
