### PR TITLE
release version 1.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,6 @@
         "dot-notation": [2],
         "eqeqeq": [2],
         "key-spacing": [2],
-        "max-len": [1, 540],
         "new-cap": [0],
         "no-bitwise": [2],
         "no-caller": [0],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
+# v1.0.0
+* Removes `shouldReRoute` method. It can now be found as a key on `findNextStep`.
+* Added 3rd required argument to `findNextStep` which is the users current step.
+* Internal logic has changed about whether the user should be rerouted. Now, the user must be within x miles of the given step, not the entire route.
+* Added new key `alertUserLevel` which is an object with keys, `high` and `low`. `high` and `low` both return booleans which are false until the user should be notified about an upcoming maneuver.
+
 # v0.2.0
 
-* `distance` is no line distance
-* Adds `absoluteDistance` which is the users absolute distance to the end of the step
+* `distance` is no line distance.
+* Adds `absoluteDistance` which is the users absolute distance to the end of the step.
 
 # v0.1.0
 
-* `maxDistance` changed to `maxReRouteDistance`
-* Added option `maxSnapToLocation`
-* `findNextStep` returns snapped location to route now on key `snapToLocation`
+* `maxDistance` changed to `maxReRouteDistance`.
+* Added option `maxSnapToLocation`.
+* `findNextStep` returns snapped location to route now on key `snapToLocation`.
 
 # v0.0.1
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var metersToFeet = 3.28084;
 module.exports = function(opts) {
     /**
     * Configuration options
-    * @param {object} `units` - either `miles` or `km`. `maxReRouteDistance` - max distance the user can be from the route. `maxSnapToLocation` - max distance to snap user to route. `completionDistance` - distance away from end of step that is considered a completion. If this distance is shorter than the step distance, it will be changed to 10ft. `warnUserTime` - number of seconds ahead of maneuver to warn user about maneuver.
+    * @param {object} `units` - either `miles` or `km`. `maxReRouteDistance` - max distance the user can be from the route. `maxSnapToLocation` - max distance to snap user to route. `completionDistance` - distance away from end of step that is considered a completion. If this distance is shorter than the step distance, it will be changed to 10ft. `warnUserTime` - number of seconds ahead of maneuver to warn user about maneuver. `shortCompletionDistance` - if the step is shorter than the `completionDistance`, this distance will be used to calculate if the step has been completed.
     */
     var options = {
         units: opts.units || 'miles',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navigation.js",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "documentation-readme": "^2.1.1",
     "eslint": "^1.10.3",
     "leaflet-hash": "^0.2.1",
-    "mapbox.js": "^2.2.4",
+    "mapbox.js": "^2.3.0",
     "request": "^2.69.0",
     "tape": "^4.4.0",
     "uglifyjs": "^2.4.10",

--- a/readme.md
+++ b/readme.md
@@ -39,4 +39,4 @@ Configuration options
 
 **Parameters**
 
--   `object`  `units` - either `miles` or `km`. `maxReRouteDistance` - max distance the user can be from the route. `maxSnapToLocation` - max distance to snap user to route. `completionDistance` - distance away from end of step that is considered a completion. If this distance is shorter than the step distance, it will be changed to 10ft. `warnUserTime` - number of seconds ahead of maneuver to warn user about maneuver.
+-   `object`  `units` - either `miles` or `km`. `maxReRouteDistance` - max distance the user can be from the route. `maxSnapToLocation` - max distance to snap user to route. `completionDistance` - distance away from end of step that is considered a completion. If this distance is shorter than the step distance, it will be changed to 10ft. `warnUserTime` - number of seconds ahead of maneuver to warn user about maneuver. `shortCompletionDistance` - if the step is shorter than the `completionDistance`, this distance will be used to calculate if the step has been completed.

--- a/tests/debug/index.js
+++ b/tests/debug/index.js
@@ -41,7 +41,8 @@ var testCases = [
 var activeTest = testCases[0].route.routes[0];
 var currentStep = 1;
 
-var map = L.mapbox.map('map', 'mapbox.streets').setView([39.9432, -75.1433], 14);
+var map = L.mapbox.map('map').setView([39.9432, -75.1433], 14);
+L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8').addTo(map);
 var marker = L.marker([0, 0]).addTo(map);
 L.hash(map);
 routeGeoJSON.addTo(map);


### PR DESCRIPTION
# v1.0.0
- Removes `shouldReRoute` method. It can now be found as a key on `findNextStep`.
- Added 3rd required argument to `findNextStep` which is the users current step.
- Internal logic has changed about whether the user should be rerouted. Now, the user must be within x miles of the given step, not the entire route.
- Added new key `alertUserLevel` which is an object with keys, `high` and `low`. `high` and `low` both return booleans which are false until the user should be notified about an upcoming maneuver.
