### PR TITLE
Fixes distance discrepancy

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = function(opts) {
         //   1. Are they within a certain threshold of the end of the step?
         //   2. If a bearing is provided, is their bearing within a current threshold of the exit bearing for the step
         //
-        var stepDistance = options.units === 'miles' ? route.steps[userCurrentStep].distance * metersToMiles : route.steps[userCurrentStep].distance * metersToKilometers;
+        var stepDistance = turfLineDistance(segmentRoute, options.units);
         // If the step distance is less than options.completionDistance, modify it and make it 10 ft
         var modifiedCompletionDistance = stepDistance < options.completionDistance ? options.shortCompletionDistance : options.completionDistance;
         // Check if users bearing is within threshold of the steps exit bearing


### PR DESCRIPTION
@bsudekum suggesting that we replace the `stepDistance` here with a [turf.js line-distance calculation](http://turfjs.org/static/docs/module-turf_line-distance.html) in lieu of using the step distance in the directions API response.

It looks like the segment distance in the directions API response is calculated from x- and y-coordinates with 6 decimal points. Since the polyline encoded on preserves 5 of these, the distances are ever-so-slightly off when they're calculated after the geometries have been decoded.

This hasn't posed a problem 99% of the time, but every now and then, the `currentStep.distance` > `currentStep.stepDistance`, which can cause some wonky behavior in visualizing maneuver countdowns.
