### PR TITLE
Calculate user completing a maneuver better

### DIFF
--- a/tests/debug/index.html
+++ b/tests/debug/index.html
@@ -37,6 +37,14 @@
       50% { opacity: 0.0; }
   }
 
+  .flashonce {
+      animation: flasher 1s linear 1;
+  }
+
+  @keyframes flasher {
+      50% { opacity: 0.0; }
+  }
+
   .arrows {
       bottom: 0;
       left:0;

--- a/tests/debug/index.js
+++ b/tests/debug/index.js
@@ -39,6 +39,10 @@ var navigation = require('../../')({
 var currentStep = 0;
 var userBearing = 0;
 
+var hasSpokenHighAlert = false;
+var hasSpokenMediumAlert = false;
+var hasSpokenLowAlert = false;
+
 map.on('mousemove', function(e) {
     if (previousUserPoint.geometry.coordinates.length > 1) {
         if ((previousUserPoint.geometry.coordinates[1] !== e.latlng.lat) || (previousUserPoint.geometry.coordinates[0] !== e.latlng.lng)) {
@@ -52,7 +56,10 @@ map.on('mousemove', function(e) {
     userLocation.geometry.coordinates[0] = e.latlng.lng;
     userLocation.geometry.coordinates[1] = e.latlng.lat;
 
-    var stepInfo = navigation.getCurrentStep(userLocation, activeRoute.legs[0], currentStep, userBearing);
+    var stepInfo = navigation.getCurrentStep(userLocation, activeRoute.legs[0], currentStep, false);
+    var feetDistance = Math.round(stepInfo.distance * 5280 / 100) * 100;
+    var distanceInstruction = feetDistance > 0 ? 'In ' + feetDistance + ' feet ' : '';
+    var instruction = activeRoute.legs[0].steps[stepInfo.step + 1].maneuver.instruction;
 
     // Display whether user should reroute in UI
     document.getElementById('reroute').innerHTML = stepInfo.shouldReRoute;
@@ -64,6 +71,8 @@ map.on('mousemove', function(e) {
         getRoute(e.latlng.lng, e.latlng.lat, -75.118674, 39.94156, userBearing, function(err, route) {
             routeGeoJSON.clearLayers();
             stepDiv.classList.remove('flash');
+            stepDiv.classList.remove('flashonce');
+            resetAlerts();
 
             // This example shows how to handle both encoded polylines and GeoJSON
             if (typeof route.routes[0].geometry === 'string') {
@@ -78,26 +87,42 @@ map.on('mousemove', function(e) {
     }
 
     // Flash the instructions to signal to the user the maneuver is coming up soon
-    if (stepInfo.alertUserLevel.high) {
+    if (stepInfo.alertUserLevel.high && !hasSpokenHighAlert) {
+        hasSpokenHighAlert = true;
+        speak(instruction);
         if (!stepDiv.classList.contains('flash')) stepDiv.classList.add('flash');
+    } else if (stepInfo.alertUserLevel.medium && !hasSpokenMediumAlert) {
+        hasSpokenMediumAlert = true;
+        speak(distanceInstruction + ' ' + instruction);
+        if (!stepDiv.classList.contains('flashonce')) stepDiv.classList.add('flashonce');
+    } else if (stepInfo.alertUserLevel.low && !hasSpokenLowAlert) {
+        hasSpokenLowAlert = true;
+        speak(distanceInstruction + ' ' + instruction);
+        if (!stepDiv.classList.contains('flashonce')) stepDiv.classList.add('flashonce');
     }
 
-    // If the calculated step is greater than the users current step, update it
-    // This means the user completed the current step. Also, turn off flashing
-    if (stepInfo.step > currentStep) {
-        currentStep = stepInfo.step;
-        stepDiv.classList.remove('flash');
-    }
+    // console.log(hasSpokenLowAlert, hasSpokenMediumAlert, hasSpokenHighAlert);
 
     // Rotate the next step maneuver angle
     rotateImage(turnArrow, activeRoute.legs[0].steps[stepInfo.step + 1].maneuver.bearing_after);
 
     // Get the instruction of the next step and display it
-    document.getElementById('step').innerHTML = 'In ' + Math.round(stepInfo.distance * 5280) + ' ft '+ activeRoute.legs[0].steps[stepInfo.step + 1].maneuver.instruction;
+    document.getElementById('step').innerHTML = 'In ' + feetDistance + 'ft ' + instruction;
     previousUserPoint = userLocation;
     previousTime = +new Date();
     // Snap the marker to closest point along the route
     marker.setLatLng([stepInfo.snapToLocation.geometry.coordinates[1], stepInfo.snapToLocation.geometry.coordinates[0]]);
+
+    // If the calculated step is greater than the users current step, update it
+    // This means the user completed the current step. Also, turn off flashing
+    if (stepInfo.step > currentStep) {
+        currentStep = stepInfo.step;
+        var fullDistance = activeRoute.legs[0].steps[currentStep].distance > 91.44 ? 'In ' + Math.round(activeRoute.legs[0].steps[currentStep].distance / 0.3048 / 100) * 100 + ' feet ' : '';
+        speak(fullDistance + instruction);
+        resetAlerts();
+        stepDiv.classList.remove('flash');
+        stepDiv.classList.remove('flashonce');
+    }
 });
 
 var getRoute = debounce(function(fromLng, fromLat, toLng, toLat, bearing, callback) {
@@ -107,6 +132,16 @@ var getRoute = debounce(function(fromLng, fromLat, toLng, toLat, bearing, callba
         if (body && res.statusCode === 200) return callback(null, JSON.parse(body));
     });
 }, 1000);
+
+var speak = debounce(function(textToSpeak) {
+    window.speechSynthesis.speak(new SpeechSynthesisUtterance(textToSpeak));
+}, 1000);
+
+function resetAlerts() {
+    hasSpokenHighAlert = false;
+    hasSpokenMediumAlert = false;
+    hasSpokenLowAlert = false;
+}
 
 function getBearing(lat1, lng1, lat2, lng2) {
     var dLon = (lng2 - lng1);

--- a/tests/navigation.test.js
+++ b/tests/navigation.test.js
@@ -38,37 +38,60 @@ test('userToRoute should not reRoute', function(t) {
 test('should signal next step', function(t) {
     var navigation = require('../')({ units: 'miles' });
     var user = {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [-75.121567, 39.944115]}};
+    var user2 = {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [-75.12160688638687, 39.94387241576697]}}; // next point along route
     routes.forEach(function(route) {
-        var nav = navigation.getCurrentStep(user, route.routes[0].legs[0], 0);
+        navigation.getCurrentStep(user, route.routes[0].legs[0], 0);
+        var nav = navigation.getCurrentStep(user2, route.routes[0].legs[0], 0);
         t.equal(nav.shouldReRoute, false);
         t.equal(nav.step, 1);
-        t.equal(Math.round(nav.absoluteDistance * 100) / 100, 0);
+        t.equal(Math.round(nav.absoluteDistance * 100) / 100, 0.02);
         t.equal(Math.round(nav.distance * 100) / 100, 0);
         t.equal(nav.alertUserLevel.low, false);
         t.equal(nav.alertUserLevel.high, true);
-        t.equal(nav.snapToLocation.geometry.coordinates[0], -75.121567);
-        t.equal(nav.snapToLocation.geometry.coordinates[1], 39.944115);
+        t.equal(nav.snapToLocation.geometry.coordinates[0], -75.12160688638687);
+        t.equal(nav.snapToLocation.geometry.coordinates[1], 39.94387241576697);
     });
     t.end();
 });
 
-test('should not signal next step if bearing is provided and not within threshold', function(t) {
+test('should signal next step if bearing is provided and not within threshold but the user exits maneuver zone', function(t) {
     var navigation = require('../')({ units: 'miles' });
     var user = {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [-75.121567, 39.944115]}};
+    var user2 = {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [-75.12160688638687, 39.94387241576697]}}; // next point along route
     routes.forEach(function(route) {
-        var nav = navigation.getCurrentStep(user, route.routes[0].legs[0], 0, 90);
+        navigation.getCurrentStep(user, route.routes[0].legs[0], 0, 0);
+        var nav = navigation.getCurrentStep(user2, route.routes[0].legs[0], 0, 0);
         t.equal(nav.shouldReRoute, false);
-        t.equal(nav.step, 0, 'step should remain zero');
-        t.equal(Math.round(nav.absoluteDistance * 100) / 100, 0);
+        t.equal(nav.step, 1, 'step should remain zero');
+        t.equal(Math.round(nav.absoluteDistance * 100) / 100, 0.02);
         t.equal(Math.round(nav.distance * 100) / 100, 0);
         t.equal(nav.alertUserLevel.low, false);
         t.equal(nav.alertUserLevel.high, true);
-        t.equal(nav.snapToLocation.geometry.coordinates[0], -75.121567);
-        t.equal(nav.snapToLocation.geometry.coordinates[1], 39.944115);
+        t.equal(nav.snapToLocation.geometry.coordinates[0], -75.12160688638687);
+        t.equal(nav.snapToLocation.geometry.coordinates[1], 39.94387241576697);
     });
     t.end();
 });
 
+test('should signal next step if bearing is provided and within threshold but the user does not exits maneuver zone', function(t) {
+    var navigation = require('../')({ units: 'miles' });
+    var user = {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [-75.121567, 39.944115]}};
+    var user2 = {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [-75.12157469987869, 39.94403898228457]}}; // next point along route
+    routes.forEach(function(route) {
+        navigation.getCurrentStep(user, route.routes[0].legs[0], 0, 0);
+        var nav = navigation.getCurrentStep(user2, route.routes[0].legs[0], 0, 175);
+        t.equal(nav.shouldReRoute, false);
+        t.equal(nav.step, 1, 'step should remain zero');
+        t.equal(Math.round(nav.absoluteDistance * 100) / 100, 0.01);
+        t.equal(Math.round(nav.distance * 100) / 100, 0);
+        t.equal(nav.alertUserLevel.low, false);
+        t.equal(nav.alertUserLevel.high, true);
+        t.equal(nav.snapToLocation.geometry.coordinates[0], -75.12157469987869);
+        t.equal(nav.snapToLocation.geometry.coordinates[1], 39.94403898228457);
+    });
+    t.end();
+});
+//
 test('should signal next step if bearing is provided and is within threshold', function(t) {
     var navigation = require('../')({ units: 'miles' });
     var user = {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [-75.121567, 39.944115]}};


### PR DESCRIPTION
This refactors a bit on how we quality if a user has completed a maneuver. Previously:

> If the user is within x units of the maneuver location, the user has completed the step.  However, if a bearing is provided, the user bearing must also be with x degrees of the `exit_bearing`.

Now:

> The user is within x units of the maneuver location. Then if this is true, once their location is greater than x units away from the maneuver location, the user has completed the step. However, if a bearing is provided, the user bearing must also be with x degrees of the `exit_bearing`.

```
                                                       Intersection

                             +----------------------+
                             |                      |
  Entering intersection      |                      |
                             |                      |
                             |                      |
+--------------------------> +---------->+          |
                             |           |          |
                             |           |  Once the user has exited the
                             |           |  intersection, they've completed
                             |           |  the step|
                             |           v          |
                             |                      |
                             +----------------------+

```

/cc @willwhite @1ec5 
